### PR TITLE
Update screensaver.mobileconfig

### DIFF
--- a/screensaver.mobileconfig
+++ b/screensaver.mobileconfig
@@ -49,7 +49,7 @@
                 <key>mcx_preference_settings</key>
                 <dict>
                   <key>askForPassword</key>
-                  <integer>1</integer>
+                  <true />
                   <key>askForPasswordDelay</key>
 		  <integer>0</integer>
 		  <key>idleTime</key>


### PR DESCRIPTION
On OSX 10.15, it appears askForPassword is now a boolean property, rather than integer.
https://developer.apple.com/documentation/devicemanagement/screensaver

I've simply updated `<integer>1</integer>` to `<true />`.